### PR TITLE
Fix LightboxGallery not showing the title and description from GalleryImage.

### DIFF
--- a/src/lib/Gallery/Gallery.svelte
+++ b/src/lib/Gallery/Gallery.svelte
@@ -147,7 +147,7 @@
                         </GalleryController>
                     </Body>
 
-                <Footer {imagePreset} {title} {description} {gallery} {...(customization.lightboxFooterProps || {})}/>
+                <Footer {imagePreset} title={activeImageTitle} description={activeImageDescription} {gallery} {...(customization.lightboxFooterProps || {})}/>
             </Modal>
         </ModalCover>
     </BodyChild>


### PR DESCRIPTION
The activeImageTitle and activeImageDescription were computed but were not passed into Footer